### PR TITLE
fixed deprecation

### DIFF
--- a/src/main/c++/bindings.cpp
+++ b/src/main/c++/bindings.cpp
@@ -10,8 +10,8 @@ void Lock(const Nan::FunctionCallbackInfo<v8::Value>& info){
 }
 
 void Init(v8::Local<v8::Object> exports){
-    exports->Set(Nan::New("isLocked").ToLocalChecked(), Nan::New<v8::FunctionTemplate>(IsLocked)->GetFunction());
-    exports->Set(Nan::New("lock").ToLocalChecked(), Nan::New<v8::FunctionTemplate>(Lock)->GetFunction());
+    exports->Set(Nan::New("isLocked").ToLocalChecked(), Nan::New<v8::FunctionTemplate>(IsLocked)->GetFunction(Nan::GetCurrentContext()).ToLocalChecked());
+    exports->Set(Nan::New("lock").ToLocalChecked(), Nan::New<v8::FunctionTemplate>(Lock)->GetFunction(Nan::GetCurrentContext()).ToLocalChecked());
 }
 
 NODE_MODULE(winlock, Init)


### PR DESCRIPTION
Fixed the deprecation of parameter-less getFunction. It now requires the local context.